### PR TITLE
feat(cli): add CLI TOTP viewer for Flauth backup files

### DIFF
--- a/.github/workflows/cli-build.yml
+++ b/.github/workflows/cli-build.yml
@@ -1,0 +1,63 @@
+name: Build CLI
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: ["main"]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+
+permissions:
+  contents: read
+
+jobs:
+  build-cli:
+    name: Build CLI (${{ matrix.label }}-${{ runner.arch }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: linux
+            extension: ""
+          - os: macos-latest
+            label: macos
+            extension: ""
+          - os: windows-latest
+            label: windows
+            extension: ".exe"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read version
+        id: version
+        run: |
+          version=$(awk '/^version:/{print $2}' pubspec.yaml | tr '+' '-')
+          echo "value=$version" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install dependencies
+        run: flutter pub get
+        shell: bash
+
+      - name: Build CLI executable
+        run: |
+          mkdir -p build
+          dart compile exe cli/main.dart -o build/flauth-cli-${{ steps.version.outputs.value }}-${{ matrix.label }}-${{ runner.arch }}${{ matrix.extension }}
+        shell: bash
+
+      - name: Upload CLI artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: flauth-cli-${{ steps.version.outputs.value }}-${{ matrix.label }}-${{ runner.arch }}${{ matrix.extension }}
+          path: build/flauth-cli-${{ steps.version.outputs.value }}-${{ matrix.label }}-${{ runner.arch }}${{ matrix.extension }}
+          if-no-files-found: error

--- a/.github/workflows/cli-build.yml
+++ b/.github/workflows/cli-build.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build-cli:
-    name: Build CLI (${{ matrix.label }}-${{ runner.arch }})
+    name: Build CLI (${{ matrix.label }}-${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -21,12 +21,15 @@ jobs:
         include:
           - os: ubuntu-latest
             label: linux
+            arch: x64
             extension: ""
           - os: macos-latest
             label: macos
+            arch: arm64
             extension: ""
           - os: windows-latest
             label: windows
+            arch: x64
             extension: ".exe"
 
     steps:
@@ -34,10 +37,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Read version
-        id: version
         run: |
           version=$(awk '/^version:/{print $2}' pubspec.yaml | tr '+' '-')
-          echo "value=$version" >> "$GITHUB_OUTPUT"
+          echo "VERSION=v$version" >> "$GITHUB_ENV"
+        shell: bash
+
+      - name: Set filename
+        run: |
+          echo "OUTFILE=flauth-cli-${{ env.VERSION }}-${{ matrix.label }}-${{ matrix.arch }}${{ matrix.extension }}" >> "$GITHUB_ENV"
         shell: bash
 
       - name: Set up Flutter
@@ -52,12 +59,12 @@ jobs:
       - name: Build CLI executable
         run: |
           mkdir -p build
-          dart compile exe cli/main.dart -o build/flauth-cli-${{ steps.version.outputs.value }}-${{ matrix.label }}-${{ runner.arch }}${{ matrix.extension }}
+          dart compile exe cli/main.dart -o build/${{ env.OUTFILE }}
         shell: bash
 
       - name: Upload CLI artifact
         uses: actions/upload-artifact@v4
         with:
-          name: flauth-cli-${{ steps.version.outputs.value }}-${{ matrix.label }}-${{ runner.arch }}${{ matrix.extension }}
-          path: build/flauth-cli-${{ steps.version.outputs.value }}-${{ matrix.label }}-${{ runner.arch }}${{ matrix.extension }}
+          name: ${{ env.OUTFILE }}
+          path: build/${{ env.OUTFILE }}
           if-no-files-found: error

--- a/.github/workflows/cli-build.yml
+++ b/.github/workflows/cli-build.yml
@@ -5,8 +5,8 @@ on:
   pull_request:
     branches: ["main"]
     paths-ignore:
-      - 'docs/**'
-      - '**.md'
+      - "docs/**"
+      - "**.md"
 
 permissions:
   contents: read
@@ -38,7 +38,7 @@ jobs:
 
       - name: Read version
         run: |
-          version=$(awk '/^version:/{print $2}' pubspec.yaml | tr '+' '-')
+          version=$(awk '/^version:/{print $2}' pubspec.yaml | cut -f1 -d'+')
           echo "VERSION=v$version" >> "$GITHUB_ENV"
         shell: bash
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 
 
 fmt:
-	dart format --set-exit-if-changed lib
+	dart format --set-exit-if-changed lib test
 
 fix:
-	dart format lib
+	dart format lib test
 
 lint:
 	flutter analyze

--- a/Makefile
+++ b/Makefile
@@ -25,4 +25,8 @@ serve:
 build-docs:
 	mkdocs build --site-dir build/website
 
-.PHONY: fmt lint test fix gen perf serve build-docs
+build-cli:
+	mkdir -p build
+	dart compile exe cli/main.dart -o build/flauth-cli
+
+.PHONY: fmt lint test fix gen perf serve build-docs build-cli

--- a/cli/account_filter.dart
+++ b/cli/account_filter.dart
@@ -1,0 +1,14 @@
+import 'package:flauth/models/account.dart';
+
+List<Account> filterAccounts(List<Account> accounts, String? filter) {
+  if (filter == null) {
+    return accounts;
+  }
+
+  final String normalizedFilter = filter.toLowerCase();
+  return accounts.where((Account account) {
+    final String issuer = account.issuer.toLowerCase();
+    final String name = account.name.toLowerCase();
+    return issuer.contains(normalizedFilter) || name.contains(normalizedFilter);
+  }).toList();
+}

--- a/cli/backup_reader.dart
+++ b/cli/backup_reader.dart
@@ -1,0 +1,138 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flauth/models/account.dart';
+import 'package:flauth/services/backup_security_service.dart';
+
+const String backupFileEnvVar = 'FLAUTH_BACKUP_FILE';
+const String backupPasswordEnvVar = 'FLAUTH_BACKUP_PASSWORD';
+
+class CliWarning {
+  final int? lineNumber;
+  final String message;
+
+  const CliWarning(this.message, {this.lineNumber});
+
+  String format() {
+    if (lineNumber == null) {
+      return message;
+    }
+    return 'line $lineNumber: $message';
+  }
+}
+
+class BackupReadResult {
+  final String backupFilePath;
+  final List<Account> accounts;
+  final List<CliWarning> warnings;
+
+  const BackupReadResult({
+    required this.backupFilePath,
+    required this.accounts,
+    required this.warnings,
+  });
+}
+
+String? resolveFilter(List<String> arguments) {
+  if (arguments.length > 1) {
+    throw const FormatException('Expected at most one filter argument.');
+  }
+
+  return _normalizedValue(arguments.isEmpty ? null : arguments.first);
+}
+
+String resolveBackupFilePath({Map<String, String>? environment}) {
+  final Map<String, String> env = environment ?? Platform.environment;
+  final String? envPath = _normalizedValue(env[backupFileEnvVar]);
+  if (envPath != null) {
+    return envPath;
+  }
+
+  throw const FormatException(
+    'Backup file is required via FLAUTH_BACKUP_FILE.',
+  );
+}
+
+Future<BackupReadResult> readBackupAccounts(
+  {Map<String, String>? environment}
+) async {
+  final Map<String, String> env = environment ?? Platform.environment;
+  final String backupFilePath = resolveBackupFilePath(environment: env);
+
+  final File backupFile = File(backupFilePath);
+  if (!await backupFile.exists()) {
+    throw FileSystemException('Backup file does not exist.', backupFilePath);
+  }
+
+  final String rawContent = await backupFile.readAsString();
+  final String content = _resolveBackupContent(rawContent, env);
+  final ParseAccountsResult parseResult = parseAccountsFromText(content);
+
+  if (parseResult.accounts.isEmpty) {
+    throw const FormatException('No valid accounts found in backup file.');
+  }
+
+  return BackupReadResult(
+    backupFilePath: backupFilePath,
+    accounts: parseResult.accounts,
+    warnings: parseResult.warnings,
+  );
+}
+
+class ParseAccountsResult {
+  final List<Account> accounts;
+  final List<CliWarning> warnings;
+
+  const ParseAccountsResult({required this.accounts, required this.warnings});
+}
+
+ParseAccountsResult parseAccountsFromText(String text) {
+  final List<Account> accounts = <Account>[];
+  final List<CliWarning> warnings = <CliWarning>[];
+  final List<String> lines = const LineSplitter().convert(text);
+
+  for (int index = 0; index < lines.length; index++) {
+    final String line = lines[index].trim();
+    if (line.isEmpty) {
+      continue;
+    }
+
+    try {
+      final Uri uri = Uri.parse(line);
+      accounts.add(Account.fromUri(uri));
+    } on FormatException catch (error) {
+      warnings.add(CliWarning(error.message, lineNumber: index + 1));
+    } catch (error) {
+      warnings.add(CliWarning(error.toString(), lineNumber: index + 1));
+    }
+  }
+
+  return ParseAccountsResult(accounts: accounts, warnings: warnings);
+}
+
+String _resolveBackupContent(
+  String rawContent,
+  Map<String, String> environment,
+) {
+  if (!BackupSecurityService.isEncrypted(rawContent)) {
+    return rawContent;
+  }
+
+  final String? password = _normalizedValue(environment[backupPasswordEnvVar]);
+  if (password == null) {
+    throw const FormatException(
+      'Encrypted backup requires FLAUTH_BACKUP_PASSWORD.',
+    );
+  }
+
+  return BackupSecurityService.decrypt(rawContent, password);
+}
+
+String? _normalizedValue(String? value) {
+  if (value == null) {
+    return null;
+  }
+
+  final String trimmed = value.trim();
+  return trimmed.isEmpty ? null : trimmed;
+}

--- a/cli/main.dart
+++ b/cli/main.dart
@@ -1,0 +1,51 @@
+import 'dart:io';
+
+import 'account_filter.dart';
+import 'backup_reader.dart';
+import 'totp_printer.dart';
+
+Future<void> main(List<String> arguments) async {
+  try {
+    final String? filter = resolveFilter(arguments);
+    final BackupReadResult readResult = await readBackupAccounts();
+    final filteredAccounts = filterAccounts(readResult.accounts, filter);
+    final TotpPrintResult printResult = buildTotpOutput(filteredAccounts);
+
+    for (final CliWarning warning in readResult.warnings) {
+      stderr.writeln('Warning: ${warning.format()}');
+    }
+    for (final CliWarning warning in printResult.warnings) {
+      stderr.writeln('Warning: ${warning.format()}');
+    }
+
+    if (printResult.output.isNotEmpty) {
+      stdout.writeln(printResult.output);
+    }
+  } catch (error) {
+    stderr.writeln('Error: ${_formatError(error)}');
+    stderr.writeln(_usage());
+    exitCode = 1;
+  }
+}
+
+String _formatError(Object error) {
+  if (error is FileSystemException) {
+    if (error.path == null || error.path!.isEmpty) {
+      return error.message;
+    }
+    return '${error.message} (${error.path})';
+  }
+
+  return error.toString().replaceFirst('Exception: ', '');
+}
+
+String _usage() {
+  return '''
+Usage:
+  dart run cli/main.dart [filter]
+
+Environment variables:
+  FLAUTH_BACKUP_FILE       Backup file path
+  FLAUTH_BACKUP_PASSWORD   Password for encrypted Flauth backups
+''';
+}

--- a/cli/main.dart
+++ b/cli/main.dart
@@ -36,6 +36,9 @@ String _formatError(Object error) {
     return '${error.message} (${error.path})';
   }
 
+  if (error is FormatException) {
+    return error.message;
+  }
   return error.toString().replaceFirst('Exception: ', '');
 }
 

--- a/cli/main.dart
+++ b/cli/main.dart
@@ -42,7 +42,7 @@ String _formatError(Object error) {
 String _usage() {
   return '''
 Usage:
-  dart run cli/main.dart [filter]
+  flauth-cli [filter]
 
 Environment variables:
   FLAUTH_BACKUP_FILE       Backup file path

--- a/cli/totp_printer.dart
+++ b/cli/totp_printer.dart
@@ -1,0 +1,79 @@
+import 'package:flauth/models/account.dart';
+import 'package:otp/otp.dart';
+
+import 'backup_reader.dart';
+
+class TotpPrintResult {
+  final String output;
+  final List<CliWarning> warnings;
+
+  const TotpPrintResult({required this.output, required this.warnings});
+}
+
+TotpPrintResult buildTotpOutput(List<Account> accounts, {DateTime? now}) {
+  final DateTime currentTime = now ?? DateTime.now();
+  final List<_RenderedAccount> rows = <_RenderedAccount>[];
+  final List<CliWarning> warnings = <CliWarning>[];
+
+  for (final Account account in accounts) {
+    final String code = _generateCurrentCode(account.secret, now: currentTime);
+    if (code == 'ERROR') {
+      final String issuer = account.issuer.isEmpty
+          ? '<unknown>'
+          : account.issuer;
+      final String name = account.name.isEmpty ? '<unknown>' : account.name;
+      warnings.add(CliWarning('Invalid secret for $issuer / $name.'));
+    }
+
+    rows.add(
+      _RenderedAccount(
+        issuer: account.issuer.isEmpty ? '-' : account.issuer,
+        name: account.name.isEmpty ? '-' : account.name,
+        code: code,
+      ),
+    );
+  }
+
+  final int issuerWidth = rows.isEmpty
+      ? 1
+      : rows.map((row) => row.issuer.length).reduce(_max);
+  final int nameWidth = rows.isEmpty
+      ? 1
+      : rows.map((row) => row.name.length).reduce(_max);
+
+  final String output = rows
+      .map(
+        (row) =>
+            '${row.issuer.padRight(issuerWidth)}  ${row.name.padRight(nameWidth)}  ${row.code}',
+      )
+      .join('\n');
+
+  return TotpPrintResult(output: output, warnings: warnings);
+}
+
+String _generateCurrentCode(String secret, {required DateTime now}) {
+  try {
+    return OTP.generateTOTPCodeString(
+      secret,
+      now.millisecondsSinceEpoch,
+      algorithm: Algorithm.SHA1,
+      isGoogle: true,
+    );
+  } catch (_) {
+    return 'ERROR';
+  }
+}
+
+int _max(int left, int right) => left > right ? left : right;
+
+class _RenderedAccount {
+  final String issuer;
+  final String name;
+  final String code;
+
+  const _RenderedAccount({
+    required this.issuer,
+    required this.name,
+    required this.code,
+  });
+}

--- a/docs/cli-totp-viewer.md
+++ b/docs/cli-totp-viewer.md
@@ -1,0 +1,66 @@
+# CLI TOTP Viewer
+
+Read a Flauth backup file and print current TOTP codes in the terminal.
+
+## Build
+
+```bash
+make build-cli
+```
+
+Output:
+
+```bash
+build/flauth-cli
+```
+
+## Environment variables
+
+- `FLAUTH_BACKUP_FILE`: required, path to the `.flauth` backup file
+- `FLAUTH_BACKUP_PASSWORD`: required only for encrypted backups
+
+## Usage
+
+Show all accounts:
+
+```bash
+FLAUTH_BACKUP_FILE=./backup.flauth ./build/flauth-cli
+```
+
+Show accounts matching a filter:
+
+```bash
+FLAUTH_BACKUP_FILE=./backup.flauth ./build/flauth-cli github
+```
+
+Show accounts from an encrypted backup:
+
+```bash
+FLAUTH_BACKUP_FILE=./backup.flauth \
+FLAUTH_BACKUP_PASSWORD='your-password' \
+./build/flauth-cli
+```
+
+The optional positional argument is a case-insensitive `contains` filter on `issuer` and `name`.
+
+## Output
+
+```text
+GitHub  alice@example.com  123456
+Google  bob@gmail.com      654321
+```
+
+Codes are printed without spaces for easier copying.
+
+## Common errors
+
+- `Backup file is required via FLAUTH_BACKUP_FILE.`
+- `Encrypted backup requires FLAUTH_BACKUP_PASSWORD.`
+- `Backup file does not exist`
+- `No valid accounts found in backup file.`
+
+## Notes
+
+- Supports plain-text and encrypted Flauth backups
+- Only reads backup files; does not modify them
+- Filter only checks `issuer` and `name`

--- a/docs/cli-totp-viewer_zh.md
+++ b/docs/cli-totp-viewer_zh.md
@@ -1,0 +1,66 @@
+# CLI TOTP 查看工具
+
+读取 Flauth 备份文件，并在终端中输出当前 TOTP 验证码。
+
+## 构建
+
+```bash
+make build-cli
+```
+
+产物：
+
+```bash
+build/flauth-cli
+```
+
+## 环境变量
+
+- `FLAUTH_BACKUP_FILE`：必填，`.flauth` 备份文件路径
+- `FLAUTH_BACKUP_PASSWORD`：仅加密备份需要
+
+## 用法
+
+显示所有账号：
+
+```bash
+FLAUTH_BACKUP_FILE=./backup.flauth ./build/flauth-cli
+```
+
+按关键字过滤：
+
+```bash
+FLAUTH_BACKUP_FILE=./backup.flauth ./build/flauth-cli github
+```
+
+读取加密备份：
+
+```bash
+FLAUTH_BACKUP_FILE=./backup.flauth \
+FLAUTH_BACKUP_PASSWORD='your-password' \
+./build/flauth-cli
+```
+
+可选位置参数是过滤条件，会对 `issuer` 和 `name` 做忽略大小写的 `contains` 匹配。
+
+## 输出
+
+```text
+GitHub  alice@example.com  123456
+Google  bob@gmail.com      654321
+```
+
+验证码中间不插空格，便于直接复制。
+
+## 常见错误
+
+- `Backup file is required via FLAUTH_BACKUP_FILE.`
+- `Encrypted backup requires FLAUTH_BACKUP_PASSWORD.`
+- `Backup file does not exist`
+- `No valid accounts found in backup file.`
+
+## 说明
+
+- 支持 Flauth 明文和加密备份
+- 只读取备份文件，不会修改文件
+- 过滤逻辑只检查 `issuer` 和 `name`

--- a/docs/cli-totp-viewer_zh.md
+++ b/docs/cli-totp-viewer_zh.md
@@ -56,7 +56,7 @@ Google  bob@gmail.com      654321
 
 - `Backup file is required via FLAUTH_BACKUP_FILE.`
 - `Encrypted backup requires FLAUTH_BACKUP_PASSWORD.`
-- `Backup file does not exist`
+- `Backup file does not exist.`
 - `No valid accounts found in backup file.`
 
 ## 说明

--- a/lib/screens/import_export_screen.dart
+++ b/lib/screens/import_export_screen.dart
@@ -541,7 +541,7 @@ class _ImportExportScreenState extends State<ImportExportScreen>
               textAlign: TextAlign.center,
               style: const TextStyle(color: Colors.grey),
             ),
-            if (extra != null) extra,
+            ?extra,
             const SizedBox(height: 48),
 
             FilledButton.icon(

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ nav:
   - Developer:
     - Android Signing: android-sign.md
     - Performance: perf.md
+    - CLI TOTP Viewer: cli-totp-viewer.md
   - Tools:
     - URI Generator: tools/uri-generator.md
   - Chinese (中文):
@@ -74,3 +75,4 @@ nav:
     - 从 Aegis 导入: import_aegis_zh.md
     - 性能优化: perf_zh.md
     - 安卓签名: android-sign_zh.md
+    - CLI TOTP 查看工具: cli-totp-viewer_zh.md

--- a/test/backup_test.dart
+++ b/test/backup_test.dart
@@ -3,21 +3,22 @@ import 'package:flauth/services/backup_security_service.dart';
 
 void main() {
   group('BackupSecurityService Tests', () {
-    const plainText = 'otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example';
+    const plainText =
+        'otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example';
     const password = 'secure-password-123';
 
     test('Encryption and Decryption should return original text', () {
       final encryptedJson = BackupSecurityService.encrypt(plainText, password);
-      
+
       expect(BackupSecurityService.isEncrypted(encryptedJson), isTrue);
-      
+
       final decrypted = BackupSecurityService.decrypt(encryptedJson, password);
       expect(decrypted, equals(plainText));
     });
 
     test('Decryption with wrong password should fail', () {
       final encryptedJson = BackupSecurityService.encrypt(plainText, password);
-      
+
       expect(
         () => BackupSecurityService.decrypt(encryptedJson, 'wrong-password'),
         throwsException,

--- a/test/cli_backup_reader_test.dart
+++ b/test/cli_backup_reader_test.dart
@@ -1,0 +1,111 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flauth/services/backup_security_service.dart';
+
+import '../cli/backup_reader.dart';
+
+void main() {
+  group('CLI backup reader', () {
+    test('reads backup file from environment variable', () {
+      final String path = resolveBackupFilePath(
+        environment: <String, String>{backupFileEnvVar: 'env.flauth'},
+      );
+
+      expect(path, 'env.flauth');
+    });
+
+    test('throws when backup file is missing', () {
+      expect(
+        () => resolveBackupFilePath(environment: const <String, String>{}),
+        throwsFormatException,
+      );
+    });
+
+    test('resolves optional filter argument', () {
+      expect(resolveFilter(<String>['Git']), 'Git');
+      expect(resolveFilter(const <String>[]), isNull);
+    });
+
+    test('throws when more than one filter argument is provided', () {
+      expect(
+        () => resolveFilter(<String>['Git', 'Hub']),
+        throwsFormatException,
+      );
+    });
+
+    test('parses plain backup text and reports invalid lines as warnings', () {
+      const String text = '''
+otpauth://totp/GitHub:alice@example.com?secret=JBSWY3DPEHPK3PXP&issuer=GitHub
+not-a-valid-uri
+otpauth://totp/Google:bob@gmail.com?secret=JBSWY3DPEHPK3PXP&issuer=Google
+''';
+
+      final ParseAccountsResult result = parseAccountsFromText(text);
+
+      expect(result.accounts, hasLength(2));
+      expect(result.accounts.first.issuer, 'GitHub');
+      expect(result.accounts.last.name, 'bob@gmail.com');
+      expect(result.warnings, hasLength(1));
+      expect(result.warnings.single.lineNumber, 2);
+    });
+
+    test(
+      'reads encrypted backup file using password environment variable',
+      () async {
+        final Directory tempDir = await Directory.systemTemp.createTemp(
+          'flauth-cli-test',
+        );
+        addTearDown(() async {
+          if (await tempDir.exists()) {
+            await tempDir.delete(recursive: true);
+          }
+        });
+
+        final File backupFile = File('${tempDir.path}/backup.flauth');
+        const String plainText =
+            'otpauth://totp/GitHub:alice@example.com?secret=JBSWY3DPEHPK3PXP&issuer=GitHub';
+        const String password = 'secure-password-123';
+        await backupFile.writeAsString(
+          BackupSecurityService.encrypt(plainText, password),
+        );
+
+        final BackupReadResult result = await readBackupAccounts(
+          environment: <String, String>{
+            backupFileEnvVar: backupFile.path,
+            backupPasswordEnvVar: password,
+          },
+        );
+
+        expect(result.backupFilePath, backupFile.path);
+        expect(result.accounts, hasLength(1));
+        expect(result.accounts.single.issuer, 'GitHub');
+      },
+    );
+
+    test('throws when encrypted backup password is missing', () async {
+      final Directory tempDir = await Directory.systemTemp.createTemp(
+        'flauth-cli-test',
+      );
+      addTearDown(() async {
+        if (await tempDir.exists()) {
+          await tempDir.delete(recursive: true);
+        }
+      });
+
+      final File backupFile = File('${tempDir.path}/backup.flauth');
+      const String plainText =
+          'otpauth://totp/GitHub:alice@example.com?secret=JBSWY3DPEHPK3PXP&issuer=GitHub';
+      await backupFile.writeAsString(
+        BackupSecurityService.encrypt(plainText, 'secure-password-123'),
+      );
+
+      expect(
+        () => readBackupAccounts(
+          environment: <String, String>{backupFileEnvVar: backupFile.path},
+        ),
+        throwsFormatException,
+      );
+    });
+  });
+}

--- a/test/cli_main_filter_test.dart
+++ b/test/cli_main_filter_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flauth/models/account.dart';
+
+import '../cli/account_filter.dart';
+
+void main() {
+  group('CLI filter behavior', () {
+    test('case-insensitive contains matches issuer or account name', () {
+      final List<Account> accounts = <Account>[
+        Account(
+          id: '1',
+          issuer: 'GitHub',
+          name: 'alice@example.com',
+          secret: 'SECRET1',
+        ),
+        Account(
+          id: '2',
+          issuer: 'Google',
+          name: 'bob@gmail.com',
+          secret: 'SECRET2',
+        ),
+      ];
+
+      expect(
+        filterAccounts(accounts, 'git').map((account) => account.issuer).toList(),
+        <String>['GitHub'],
+      );
+      expect(
+        filterAccounts(accounts, 'BOB').map((account) => account.name).toList(),
+        <String>['bob@gmail.com'],
+      );
+      expect(filterAccounts(accounts, null), accounts);
+    });
+  });
+}

--- a/test/cli_main_filter_test.dart
+++ b/test/cli_main_filter_test.dart
@@ -22,7 +22,10 @@ void main() {
       ];
 
       expect(
-        filterAccounts(accounts, 'git').map((account) => account.issuer).toList(),
+        filterAccounts(
+          accounts,
+          'git',
+        ).map((account) => account.issuer).toList(),
         <String>['GitHub'],
       );
       expect(

--- a/test/cli_totp_printer_test.dart
+++ b/test/cli_totp_printer_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flauth/models/account.dart';
+
+import '../cli/totp_printer.dart';
+
+void main() {
+  group('CLI TOTP printer', () {
+    test('prints current code output without inserted spacing', () {
+      final List<Account> accounts = <Account>[
+        Account(
+          id: '1',
+          issuer: 'GitHub',
+          name: 'alice@example.com',
+          secret: 'JBSWY3DPEHPK3PXP',
+        ),
+      ];
+
+      final TotpPrintResult result = buildTotpOutput(
+        accounts,
+        now: DateTime.fromMillisecondsSinceEpoch(0),
+      );
+
+      expect(result.warnings, isEmpty);
+      expect(result.output, contains('GitHub  alice@example.com  282760'));
+    });
+
+    test('prints ERROR and warning for invalid secret', () {
+      final List<Account> accounts = <Account>[
+        Account(
+          id: '1',
+          issuer: 'Broken',
+          name: 'alice@example.com',
+          secret: '%%%%',
+        ),
+      ];
+
+      final TotpPrintResult result = buildTotpOutput(
+        accounts,
+        now: DateTime.fromMillisecondsSinceEpoch(0),
+      );
+
+      expect(result.output, contains('ERROR'));
+      expect(result.warnings, hasLength(1));
+      expect(
+        result.warnings.single.format(),
+        'Invalid secret for Broken / alice@example.com.',
+      );
+    });
+  });
+}


### PR DESCRIPTION
Introduce a command line tool to read Flauth backup files and print current TOTP codes in the terminal. The CLI supports both plain and encrypted backups, allows account filtering, and provides user-friendly warnings and error messages. This improves accessibility for users who prefer managing OTP accounts outside mobile apps.

Add:
- Standalone Dart CLI that loads .flauth backup via environment variable
- Filtering support for issuer and name via command line argument
- Output formatting optimized for shell usage
- Test coverage for core reader, filter, and output
- English and Chinese documentation for the new tool
- Makefile rule for building the executable

This change enables headless and automation-friendly workflows with Flauth account data.