### PR TITLE
feat(home): add manual account entry with FAB speed dial

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -5,6 +5,7 @@ import '../providers/auth_provider.dart';
 import '../models/account.dart';
 import '../widgets/account_tile.dart';
 import 'scan_qr_screen.dart';
+import 'manual_entry_screen.dart';
 import 'import_export_screen.dart';
 import 'about_screen.dart';
 import 'security_screen.dart';
@@ -16,11 +17,24 @@ class HomeScreen extends StatefulWidget {
   State<HomeScreen> createState() => _HomeScreenState();
 }
 
-class _HomeScreenState extends State<HomeScreen> {
+class _HomeScreenState extends State<HomeScreen>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _fabController;
+
   @override
   void initState() {
     super.initState();
+    _fabController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 250),
+    );
     WidgetsBinding.instance.addPostFrameCallback((_) => _checkSecuritySetup());
+  }
+
+  @override
+  void dispose() {
+    _fabController.dispose();
+    super.dispose();
   }
 
   Future<void> _checkSecuritySetup() async {
@@ -111,7 +125,7 @@ class _HomeScreenState extends State<HomeScreen> {
                     ).textTheme.titleLarge?.copyWith(color: Colors.grey),
                   ),
                   const SizedBox(height: 8),
-                  const Text('Tap the button below to scan a QR code'),
+                  const Text('Tap + to add an account'),
                 ],
               ),
             );
@@ -137,14 +151,117 @@ class _HomeScreenState extends State<HomeScreen> {
           );
         },
       ),
-      floatingActionButton: FloatingActionButton.extended(
-        onPressed: () {
-          Navigator.of(
-            context,
-          ).push(MaterialPageRoute(builder: (context) => const ScanQrScreen()));
+      floatingActionButton: _SpeedDialFab(
+        controller: _fabController,
+        onScanQr: () {
+          Navigator.of(context).push(
+            MaterialPageRoute(builder: (context) => const ScanQrScreen()),
+          );
         },
-        icon: const Icon(Icons.qr_code_scanner),
-        label: const Text('Scan'),
+        onManualEntry: () {
+          Navigator.of(context).push(
+            MaterialPageRoute(builder: (context) => const ManualEntryScreen()),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _SpeedDialFab extends StatelessWidget {
+  final AnimationController controller;
+  final VoidCallback onScanQr;
+  final VoidCallback onManualEntry;
+
+  const _SpeedDialFab({
+    required this.controller,
+    required this.onScanQr,
+    required this.onManualEntry,
+  });
+
+  void _toggle() {
+    if (controller.isCompleted) {
+      controller.reverse();
+    } else {
+      controller.forward();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: controller,
+      builder: (context, child) {
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            if (controller.value > 0) ...[
+              _buildMiniAction(
+                label: 'Manual Entry',
+                icon: Icons.keyboard,
+                onPressed: () {
+                  controller.reverse();
+                  onManualEntry();
+                },
+                progress: controller.value,
+              ),
+              const SizedBox(height: 12),
+              _buildMiniAction(
+                label: 'Scan QR',
+                icon: Icons.qr_code_scanner,
+                onPressed: () {
+                  controller.reverse();
+                  onScanQr();
+                },
+                progress: controller.value,
+              ),
+              const SizedBox(height: 12),
+            ],
+            FloatingActionButton(
+              onPressed: _toggle,
+              child: AnimatedRotation(
+                turns: controller.value * 0.125,
+                duration: const Duration(milliseconds: 250),
+                child: const Icon(Icons.add),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildMiniAction({
+    required String label,
+    required IconData icon,
+    required VoidCallback onPressed,
+    required double progress,
+  }) {
+    return Opacity(
+      opacity: progress,
+      child: Transform.scale(
+        scale: progress,
+        alignment: Alignment.bottomRight,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Material(
+              elevation: 2,
+              borderRadius: BorderRadius.circular(4),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                child: Text(label, style: const TextStyle(fontSize: 12)),
+              ),
+            ),
+            const SizedBox(width: 8),
+            FloatingActionButton.small(
+              heroTag: label,
+              onPressed: onPressed,
+              child: Icon(icon),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -168,7 +168,7 @@ class _HomeScreenState extends State<HomeScreen>
   }
 }
 
-class _SpeedDialFab extends StatelessWidget {
+class _SpeedDialFab extends StatefulWidget {
   final AnimationController controller;
   final VoidCallback onScanQr;
   final VoidCallback onManualEntry;
@@ -179,11 +179,27 @@ class _SpeedDialFab extends StatelessWidget {
     required this.onManualEntry,
   });
 
+  @override
+  State<_SpeedDialFab> createState() => _SpeedDialFabState();
+}
+
+class _SpeedDialFabState extends State<_SpeedDialFab> {
+  late final Animation<double> _rotationAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _rotationAnimation = Tween<double>(
+      begin: 0.0,
+      end: 0.125,
+    ).animate(widget.controller);
+  }
+
   void _toggle() {
-    if (controller.isCompleted) {
-      controller.reverse();
+    if (widget.controller.isCompleted) {
+      widget.controller.reverse();
     } else {
-      controller.forward();
+      widget.controller.forward();
     }
   }
 
@@ -193,11 +209,11 @@ class _SpeedDialFab extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.end,
       children: [
-        SizeTransition(
-          sizeFactor: controller,
-          axisAlignment: 1.0,
+        ScaleTransition(
+          scale: widget.controller,
+          alignment: Alignment.bottomRight,
           child: FadeTransition(
-            opacity: controller,
+            opacity: widget.controller,
             child: Column(
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.end,
@@ -206,8 +222,8 @@ class _SpeedDialFab extends StatelessWidget {
                   label: 'Manual Entry',
                   icon: Icons.keyboard,
                   onPressed: () {
-                    controller.reverse();
-                    onManualEntry();
+                    widget.controller.reverse();
+                    widget.onManualEntry();
                   },
                 ),
                 const SizedBox(height: 12),
@@ -215,8 +231,8 @@ class _SpeedDialFab extends StatelessWidget {
                   label: 'Scan QR',
                   icon: Icons.qr_code_scanner,
                   onPressed: () {
-                    controller.reverse();
-                    onScanQr();
+                    widget.controller.reverse();
+                    widget.onScanQr();
                   },
                 ),
                 const SizedBox(height: 12),
@@ -227,7 +243,7 @@ class _SpeedDialFab extends StatelessWidget {
         FloatingActionButton(
           onPressed: _toggle,
           child: RotationTransition(
-            turns: Tween<double>(begin: 0.0, end: 0.125).animate(controller),
+            turns: _rotationAnimation,
             child: const Icon(Icons.add),
           ),
         ),

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -154,9 +154,9 @@ class _HomeScreenState extends State<HomeScreen>
       floatingActionButton: _SpeedDialFab(
         controller: _fabController,
         onScanQr: () {
-          Navigator.of(context).push(
-            MaterialPageRoute(builder: (context) => const ScanQrScreen()),
-          );
+          Navigator.of(
+            context,
+          ).push(MaterialPageRoute(builder: (context) => const ScanQrScreen()));
         },
         onManualEntry: () {
           Navigator.of(context).push(
@@ -189,46 +189,49 @@ class _SpeedDialFab extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return AnimatedBuilder(
-      animation: controller,
-      builder: (context, child) {
-        return Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.end,
-          children: [
-            if (controller.value > 0) ...[
-              _buildMiniAction(
-                label: 'Manual Entry',
-                icon: Icons.keyboard,
-                onPressed: () {
-                  controller.reverse();
-                  onManualEntry();
-                },
-                progress: controller.value,
-              ),
-              const SizedBox(height: 12),
-              _buildMiniAction(
-                label: 'Scan QR',
-                icon: Icons.qr_code_scanner,
-                onPressed: () {
-                  controller.reverse();
-                  onScanQr();
-                },
-                progress: controller.value,
-              ),
-              const SizedBox(height: 12),
-            ],
-            FloatingActionButton(
-              onPressed: _toggle,
-              child: AnimatedRotation(
-                turns: controller.value * 0.125,
-                duration: const Duration(milliseconds: 250),
-                child: const Icon(Icons.add),
-              ),
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        SizeTransition(
+          sizeFactor: controller,
+          axisAlignment: 1.0,
+          child: FadeTransition(
+            opacity: controller,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                _buildMiniAction(
+                  label: 'Manual Entry',
+                  icon: Icons.keyboard,
+                  onPressed: () {
+                    controller.reverse();
+                    onManualEntry();
+                  },
+                ),
+                const SizedBox(height: 12),
+                _buildMiniAction(
+                  label: 'Scan QR',
+                  icon: Icons.qr_code_scanner,
+                  onPressed: () {
+                    controller.reverse();
+                    onScanQr();
+                  },
+                ),
+                const SizedBox(height: 12),
+              ],
             ),
-          ],
-        );
-      },
+          ),
+        ),
+        FloatingActionButton(
+          onPressed: _toggle,
+          child: RotationTransition(
+            turns: Tween<double>(begin: 0.0, end: 0.125).animate(controller),
+            child: const Icon(Icons.add),
+          ),
+        ),
+      ],
     );
   }
 
@@ -236,33 +239,25 @@ class _SpeedDialFab extends StatelessWidget {
     required String label,
     required IconData icon,
     required VoidCallback onPressed,
-    required double progress,
   }) {
-    return Opacity(
-      opacity: progress,
-      child: Transform.scale(
-        scale: progress,
-        alignment: Alignment.bottomRight,
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Material(
-              elevation: 2,
-              borderRadius: BorderRadius.circular(4),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                child: Text(label, style: const TextStyle(fontSize: 12)),
-              ),
-            ),
-            const SizedBox(width: 8),
-            FloatingActionButton.small(
-              heroTag: label,
-              onPressed: onPressed,
-              child: Icon(icon),
-            ),
-          ],
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Material(
+          elevation: 2,
+          borderRadius: BorderRadius.circular(4),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            child: Text(label, style: const TextStyle(fontSize: 12)),
+          ),
         ),
-      ),
+        const SizedBox(width: 8),
+        FloatingActionButton.small(
+          heroTag: label,
+          onPressed: onPressed,
+          child: Icon(icon),
+        ),
+      ],
     );
   }
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -17,24 +17,11 @@ class HomeScreen extends StatefulWidget {
   State<HomeScreen> createState() => _HomeScreenState();
 }
 
-class _HomeScreenState extends State<HomeScreen>
-    with SingleTickerProviderStateMixin {
-  late final AnimationController _fabController;
-
+class _HomeScreenState extends State<HomeScreen> {
   @override
   void initState() {
     super.initState();
-    _fabController = AnimationController(
-      vsync: this,
-      duration: const Duration(milliseconds: 250),
-    );
     WidgetsBinding.instance.addPostFrameCallback((_) => _checkSecuritySetup());
-  }
-
-  @override
-  void dispose() {
-    _fabController.dispose();
-    super.dispose();
   }
 
   Future<void> _checkSecuritySetup() async {
@@ -152,7 +139,6 @@ class _HomeScreenState extends State<HomeScreen>
         },
       ),
       floatingActionButton: _SpeedDialFab(
-        controller: _fabController,
         onScanQr: () {
           Navigator.of(
             context,
@@ -169,12 +155,10 @@ class _HomeScreenState extends State<HomeScreen>
 }
 
 class _SpeedDialFab extends StatefulWidget {
-  final AnimationController controller;
   final VoidCallback onScanQr;
   final VoidCallback onManualEntry;
 
   const _SpeedDialFab({
-    required this.controller,
     required this.onScanQr,
     required this.onManualEntry,
   });
@@ -183,23 +167,35 @@ class _SpeedDialFab extends StatefulWidget {
   State<_SpeedDialFab> createState() => _SpeedDialFabState();
 }
 
-class _SpeedDialFabState extends State<_SpeedDialFab> {
+class _SpeedDialFabState extends State<_SpeedDialFab>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
   late final Animation<double> _rotationAnimation;
 
   @override
   void initState() {
     super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 250),
+    );
     _rotationAnimation = Tween<double>(
       begin: 0.0,
       end: 0.125,
-    ).animate(widget.controller);
+    ).animate(_controller);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
   }
 
   void _toggle() {
-    if (widget.controller.isCompleted) {
-      widget.controller.reverse();
+    if (_controller.isCompleted) {
+      _controller.reverse();
     } else {
-      widget.controller.forward();
+      _controller.forward();
     }
   }
 
@@ -209,38 +205,51 @@ class _SpeedDialFabState extends State<_SpeedDialFab> {
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.end,
       children: [
-        ScaleTransition(
-          scale: widget.controller,
-          alignment: Alignment.bottomRight,
-          child: FadeTransition(
-            opacity: widget.controller,
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.end,
-              children: [
-                _buildMiniAction(
-                  label: 'Manual Entry',
-                  icon: Icons.keyboard,
-                  onPressed: () {
-                    widget.controller.reverse();
-                    widget.onManualEntry();
-                  },
+        AnimatedBuilder(
+          animation: _controller,
+          builder: (context, child) {
+            return IgnorePointer(
+              ignoring: _controller.isDismissed,
+              child: child,
+            );
+          },
+          child: SizeTransition(
+            sizeFactor: _controller,
+            axisAlignment: 1.0,
+            child: FadeTransition(
+              opacity: _controller,
+              child: Align(
+                alignment: Alignment.centerRight,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    _buildMiniAction(
+                      label: 'Manual Entry',
+                      icon: Icons.keyboard,
+                      onPressed: () {
+                        _controller.reverse();
+                        widget.onManualEntry();
+                      },
+                    ),
+                    const SizedBox(height: 12),
+                    _buildMiniAction(
+                      label: 'Scan QR',
+                      icon: Icons.qr_code_scanner,
+                      onPressed: () {
+                        _controller.reverse();
+                        widget.onScanQr();
+                      },
+                    ),
+                    const SizedBox(height: 12),
+                  ],
                 ),
-                const SizedBox(height: 12),
-                _buildMiniAction(
-                  label: 'Scan QR',
-                  icon: Icons.qr_code_scanner,
-                  onPressed: () {
-                    widget.controller.reverse();
-                    widget.onScanQr();
-                  },
-                ),
-                const SizedBox(height: 12),
-              ],
+              ),
             ),
           ),
         ),
         FloatingActionButton(
+          heroTag: 'main_fab',
           onPressed: _toggle,
           child: RotationTransition(
             turns: _rotationAnimation,

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -158,10 +158,7 @@ class _SpeedDialFab extends StatefulWidget {
   final VoidCallback onScanQr;
   final VoidCallback onManualEntry;
 
-  const _SpeedDialFab({
-    required this.onScanQr,
-    required this.onManualEntry,
-  });
+  const _SpeedDialFab({required this.onScanQr, required this.onManualEntry});
 
   @override
   State<_SpeedDialFab> createState() => _SpeedDialFabState();

--- a/lib/screens/manual_entry_screen.dart
+++ b/lib/screens/manual_entry_screen.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/account_provider.dart';
+
+bool isValidBase32(String input) {
+  final cleaned = input.replaceAll(' ', '').toUpperCase();
+  if (cleaned.isEmpty) return false;
+  return RegExp(r'^[A-Z2-7]+=*$').hasMatch(cleaned);
+}
+
+class ManualEntryScreen extends StatefulWidget {
+  const ManualEntryScreen({super.key});
+
+  @override
+  State<ManualEntryScreen> createState() => _ManualEntryScreenState();
+}
+
+class _ManualEntryScreenState extends State<ManualEntryScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _issuerController = TextEditingController();
+  final _nameController = TextEditingController();
+  final _secretController = TextEditingController();
+  bool _isSubmitting = false;
+
+  @override
+  void dispose() {
+    _issuerController.dispose();
+    _nameController.dispose();
+    _secretController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    setState(() => _isSubmitting = true);
+
+    final issuer = _issuerController.text.trim();
+    final name = _nameController.text.trim();
+    final secret = _secretController.text.trim();
+
+    final success = await Provider.of<AccountProvider>(
+      context,
+      listen: false,
+    ).addAccount(name, secret, issuer: issuer);
+
+    if (!mounted) return;
+
+    setState(() => _isSubmitting = false);
+
+    if (success) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Added account: $name')),
+      );
+      Navigator.of(context).pop();
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Account already exists'),
+          backgroundColor: Colors.orange,
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Add Account')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              TextFormField(
+                controller: _issuerController,
+                decoration: const InputDecoration(
+                  labelText: 'Issuer (optional)',
+                  hintText: 'e.g. Google, GitHub',
+                  prefixIcon: Icon(Icons.business),
+                ),
+                textInputAction: TextInputAction.next,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _nameController,
+                decoration: const InputDecoration(
+                  labelText: 'Account Name',
+                  hintText: 'e.g. user@example.com',
+                  prefixIcon: Icon(Icons.person),
+                ),
+                textInputAction: TextInputAction.next,
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Account name is required';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _secretController,
+                decoration: const InputDecoration(
+                  labelText: 'Secret Key',
+                  hintText: 'e.g. JBSWY3DPEHPK3PXP',
+                  prefixIcon: Icon(Icons.key),
+                ),
+                textInputAction: TextInputAction.done,
+                textCapitalization: TextCapitalization.characters,
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Secret key is required';
+                  }
+                  if (!isValidBase32(value)) {
+                    return 'Invalid secret key (must be Base32)';
+                  }
+                  return null;
+                },
+                onFieldSubmitted: (_) => _submit(),
+              ),
+              const SizedBox(height: 24),
+              FilledButton(
+                onPressed: _isSubmitting ? null : _submit,
+                child: _isSubmitting
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Add Account'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/manual_entry_screen.dart
+++ b/lib/screens/manual_entry_screen.dart
@@ -49,9 +49,9 @@ class _ManualEntryScreenState extends State<ManualEntryScreen> {
     setState(() => _isSubmitting = false);
 
     if (success) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Added account: $name')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Added account: $name')));
       Navigator.of(context).pop();
     } else {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -109,6 +109,8 @@ class _ManualEntryScreenState extends State<ManualEntryScreen> {
                 ),
                 textInputAction: TextInputAction.done,
                 textCapitalization: TextCapitalization.characters,
+                autocorrect: false,
+                enableSuggestions: false,
                 validator: (value) {
                   if (value == null || value.trim().isEmpty) {
                     return 'Secret key is required';

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -8,9 +8,6 @@ PODS:
   - local_auth_darwin (0.0.1):
     - Flutter
     - FlutterMacOS
-  - mobile_scanner (7.0.0):
-    - Flutter
-    - FlutterMacOS
   - package_info_plus (0.0.1):
     - FlutterMacOS
   - path_provider_foundation (0.0.1):
@@ -24,7 +21,6 @@ DEPENDENCIES:
   - flutter_secure_storage_darwin (from `Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - local_auth_darwin (from `Flutter/ephemeral/.symlinks/plugins/local_auth_darwin/darwin`)
-  - mobile_scanner (from `Flutter/ephemeral/.symlinks/plugins/mobile_scanner/darwin`)
   - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
   - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
   - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
@@ -38,8 +34,6 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral
   local_auth_darwin:
     :path: Flutter/ephemeral/.symlinks/plugins/local_auth_darwin/darwin
-  mobile_scanner:
-    :path: Flutter/ephemeral/.symlinks/plugins/mobile_scanner/darwin
   package_info_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
   path_provider_foundation:
@@ -52,7 +46,6 @@ SPEC CHECKSUMS:
   flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   local_auth_darwin: c3ee6cce0a8d56be34c8ccb66ba31f7f180aaebb
-  mobile_scanner: 9157936403f5a0644ca3779a38ff8404c5434a93
   package_info_plus: f0052d280d17aa382b932f399edf32507174e870
   path_provider_foundation: bb55f6dbba17d0dccd6737fe6f7f34fbd0376880
   url_launcher_macos: f87a979182d112f911de6820aefddaf56ee9fbfd

--- a/metadata/en-US/changelogs/2002.txt
+++ b/metadata/en-US/changelogs/2002.txt
@@ -1,0 +1,3 @@
+* Add manual account entry
+
+  You can now add TOTP accounts by manually entering the issuer, account name, and secret key. Tap the + button on the home screen to choose between scanning a QR code or manual entry.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.1+1
+version: 1.1.0+2
 
 environment:
   sdk: ^3.10.4

--- a/test/manual_entry_validation_test.dart
+++ b/test/manual_entry_validation_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flauth/screens/manual_entry_screen.dart';
+
+void main() {
+  group('isValidBase32', () {
+    test('accepts valid Base32 strings', () {
+      expect(isValidBase32('JBSWY3DPEHPK3PXP'), true);
+      expect(isValidBase32('ABCDEFGHIJKLMNOP'), true);
+      expect(isValidBase32('MFRA===='), true);
+      expect(isValidBase32('AB234567'), true);
+    });
+
+    test('accepts strings with spaces (stripped before check)', () {
+      expect(isValidBase32('JBSW Y3DP EHPK 3PXP'), true);
+    });
+
+    test('accepts lowercase (uppercased before check)', () {
+      expect(isValidBase32('jbswy3dpehpk3pxp'), true);
+    });
+
+    test('rejects empty string', () {
+      expect(isValidBase32(''), false);
+      expect(isValidBase32('   '), false);
+    });
+
+    test('rejects invalid characters', () {
+      expect(isValidBase32('JBSWY3DP!'), false);
+      expect(isValidBase32('01489'), false);
+    });
+
+    test('rejects strings with only invalid chars', () {
+      expect(isValidBase32('!!!'), false);
+      expect(isValidBase32('189'), false);
+    });
+  });
+}


### PR DESCRIPTION
Introduce manual account entry screen and speed dial FAB for account addition. Users can now add accounts by entering details manually or by scanning a QR code. This improves usability for scenarios where QR is unavailable or impractical. Includes input validation and test coverage for base32 secret keys.

Close #20